### PR TITLE
Bug fix in message.js

### DIFF
--- a/js/chat/message.js
+++ b/js/chat/message.js
@@ -100,6 +100,7 @@ export default class Mars5eMessage extends ChatMessage {
     const card = ev.target.closest("li.chat-message");
     const messageId = card?.dataset.messageId;
     const message = game.messages.get(messageId);
+    if (!card) return;
     message._card = card.querySelector(".mars5e-card");
     return message;
   }


### PR DESCRIPTION
This fixes an error message that occurs when clicking in the chat log, but not on a chat message or card, caused by a null ```card``` constant.