### PR TITLE
Fixed route-prefix import issue by using a dynamic `import()` statement to grab greensock.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -10,16 +10,14 @@ import templateAutotargeting from "./item/ability-template.js";
 import Mars5eUserStatistics from "./statistics.js";
 
 import { initConfetti, log } from "./util.js";
+import { TweenMax } from '../../../../scripts/greensock/esm/gsap-core.js';
 import { initAutomatedAnimations } from "./plugins/automated-animations.js";
 
 Hooks.once("devModeReady", ({ registerPackageDebugFlag }) => {
   registerPackageDebugFlag("mars-5e");
 });
 
-Hooks.on("init", async () => {
-  // Dynamic fetch of Greensock respecting route prefix
-  let gs = await import(`/${ROUTE_PREFIX}/scripts/greensock/esm/all.js`);
-
+Hooks.on("init", () => {
   window["mars5e"] = {};
   const MarsItem5e = initItemClass();
   CONFIG.Item.documentClass = MarsItem5e;
@@ -58,7 +56,7 @@ Hooks.on("init", async () => {
     return ret;
   };
   const classList = ".item .item-name, .ability,  .skill, .macro";
-  let tween = gs.TweenMax.to(mars5e.advDiv, 1, {
+  let tween = TweenMax.to(mars5e.advDiv, 1, {
     onComplete: () => {
       mars5e.advDiv.classList.add("mars5e-show-hint");
     },

--- a/js/index.js
+++ b/js/index.js
@@ -10,7 +10,7 @@ import templateAutotargeting from "./item/ability-template.js";
 import Mars5eUserStatistics from "./statistics.js";
 
 import { initConfetti, log } from "./util.js";
-import { TweenMax } from '../../../../scripts/greensock/esm/gsap-core.js';
+import { TweenMax } from '../../../scripts/greensock/esm/gsap-core.js';
 import { initAutomatedAnimations } from "./plugins/automated-animations.js";
 
 Hooks.once("devModeReady", ({ registerPackageDebugFlag }) => {

--- a/js/index.js
+++ b/js/index.js
@@ -10,14 +10,16 @@ import templateAutotargeting from "./item/ability-template.js";
 import Mars5eUserStatistics from "./statistics.js";
 
 import { initConfetti, log } from "./util.js";
-import { TweenMax } from "/scripts/greensock/esm/all.js";
 import { initAutomatedAnimations } from "./plugins/automated-animations.js";
 
 Hooks.once("devModeReady", ({ registerPackageDebugFlag }) => {
   registerPackageDebugFlag("mars-5e");
 });
 
-Hooks.on("init", () => {
+Hooks.on("init", async () => {
+  // Dynamic fetch of Greensock respecting route prefix
+  let gs = await import(`/${ROUTE_PREFIX}/scripts/greensock/esm/all.js`);
+
   window["mars5e"] = {};
   const MarsItem5e = initItemClass();
   CONFIG.Item.documentClass = MarsItem5e;
@@ -56,7 +58,7 @@ Hooks.on("init", () => {
     return ret;
   };
   const classList = ".item .item-name, .ability,  .skill, .macro";
-  let tween = TweenMax.to(mars5e.advDiv, 1, {
+  let tween = gs.TweenMax.to(mars5e.advDiv, 1, {
     onComplete: () => {
       mars5e.advDiv.classList.add("mars5e-show-hint");
     },


### PR DESCRIPTION
Fixes #112 

Should work on all modern browsers, based on https://caniuse.com/?search=import(). That being said, I do not know how to test it on the Electron app, having never used it myself.

Pretty quick and dirty fix. Let me know if anything seems amiss.